### PR TITLE
Allow intermediate streams to be escaped safely

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * @param {string} txt - String to escape.
  * @return {string}    - Escaped string.
  */
-function esc(txt) {
+function escapeCarriageReturn(txt) {
   if (!txt) return "";
   if (!/\r/.test(txt)) return txt;
   txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
@@ -26,7 +26,7 @@ function findLongestString(arr) {
   return longest;
 }
 
-function escSingleLineSafe(txt) {
+function escapeSingleLineSafe(txt) {
   if (!/\r/.test(txt)) return txt;
   var arr = txt.split("\r");
   var res = [];
@@ -48,14 +48,20 @@ function escSingleLineSafe(txt) {
  * @param {string} txt - String to escape.
  * @return {string}    - Escaped string.
  */
-function escSafe(txt) {
+function escapeCarriageReturnSafe(txt) {
   if (!txt) return "";
   if (!/\r/.test(txt)) return txt;
-  if (!/\n/.test(txt)) return escSingleLineSafe(txt);
+  if (!/\n/.test(txt)) return escapeSingleLineSafe(txt);
   txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
   var idx = txt.lastIndexOf("\n");
-  return esc(txt.slice(0, idx)) + "\n" + escSingleLineSafe(txt.slice(idx + 1));
+
+  return (
+    escapeCarriageReturn(txt.slice(0, idx)) +
+    "\n" +
+    escapeSingleLineSafe(txt.slice(idx + 1))
+  );
 }
 
-exports.escapeCarriageReturn = esc;
-exports.escapeCarriageReturnSafe = escSafe;
+module.exports = escapeCarriageReturn;
+module.exports.escapeCarriageReturn = escapeCarriageReturn;
+module.exports.escapeCarriageReturnSafe = escapeCarriageReturnSafe;

--- a/index.js
+++ b/index.js
@@ -1,14 +1,61 @@
-function escapeCarriageReturn(txt) {
-  if (!txt) return '';
+/**
+ * Escape carrigage returns like a terminal
+ * @param {string} txt - String to escape.
+ * @return {string}    - Escaped string.
+ */
+function esc(txt) {
+  if (!txt) return "";
   if (!/\r/.test(txt)) return txt;
-  txt = txt.replace(/\r+\n/gm, '\n'); // \r followed by \n --> newline
+  txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
   while (/\r[^$]/.test(txt)) {
     var base = /^(.*)\r+/m.exec(txt)[1];
     var insert = /\r+(.*)$/m.exec(txt)[1];
     insert = insert + base.slice(insert.length, base.length);
-    txt = txt.replace(/\r+.*$/m, '\r').replace(/^.*\r/m, insert);
+    txt = txt.replace(/\r+.*$/m, "\r").replace(/^.*\r/m, insert);
   }
   return txt;
 }
 
-module.exports = escapeCarriageReturn;
+function findLongestString(arr) {
+  var longest = 0;
+  for (var i = 0; i < arr.length; i++) {
+    if (arr[longest].length <= arr[i].length) {
+      longest = i;
+    }
+  }
+  return longest;
+}
+
+function escSingleLineSafe(txt) {
+  if (!/\r/.test(txt)) return txt;
+  var arr = txt.split("\r");
+  var res = [];
+
+  while (arr.length > 0) {
+    var longest = findLongestString(arr);
+    res.push(arr[longest]);
+    arr = arr.slice(longest + 1);
+  }
+
+  return res.join("\r");
+}
+
+/**
+ * Safely escape carrigage returns like a terminal.
+ * This allows to escape carrigage returns while allowing future output to be appended
+ * without loosing information.
+ * Use this as a intermediate escape step if your stream hasn't completed yet.
+ * @param {string} txt - String to escape.
+ * @return {string}    - Escaped string.
+ */
+function escSafe(txt) {
+  if (!txt) return "";
+  if (!/\r/.test(txt)) return txt;
+  if (!/\n/.test(txt)) return escSingleLineSafe(txt);
+  txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
+  var idx = txt.lastIndexOf("\n");
+  return esc(txt.slice(0, idx)) + "\n" + escSingleLineSafe(txt.slice(idx + 1));
+}
+
+exports.escapeCarriageReturn = esc;
+exports.escapeCarriageReturnSafe = escSafe;

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -1,37 +1,88 @@
-var escapeCarriageReturn = require('../index');
-var expect = require('chai').expect;
+var escapeCarriageReturn = require("../index").escapeCarriageReturn;
+var escapeCarriageReturnSafe = require("../index").escapeCarriageReturnSafe;
+var expect = require("chai").expect;
 
-describe('Escape carrigage return', function() {
-  it('can handle carrigage symbol', function() {
-    var txt = escapeCarriageReturn('This sentence\rThat\nwill make you pause.');
-    expect(txt).to.equal('That sentence\nwill make you pause.');
+describe("Escape carrigage return", function() {
+  it("can handle carrigage symbol", function() {
+    var txt = escapeCarriageReturn("This sentence\rThat\nwill make you pause.");
+    expect(txt).to.equal("That sentence\nwill make you pause.");
   });
 
-  it('can handle carrigage symbol without new line', function() {
-    var txt = escapeCarriageReturn('1\r2\r3');
-    expect(txt).to.equal('3');
+  it("can handle carrigage symbol without new line", function() {
+    var txt = escapeCarriageReturn("1\r2\r3");
+    expect(txt).to.equal("3");
   });
 
-  it('can handle complicated carrigage symbol', function() {
+  it("can handle complicated carrigage symbol", function() {
     var input = [
-      'hasrn\r\n',
-      'hasn\n',
-      '\n',
-      'abcdef\r',
-      'hello\n',
-      'ab3\r',
-      'x2\r\r',
-      '1\r',
-    ].join('');
+      "hasrn\r\n",
+      "hasn\n",
+      "\n",
+      "abcdef\r",
+      "hello\n",
+      "ab3\r",
+      "x2\r\r",
+      "1\r"
+    ].join("");
 
-    var output = [
-      'hasrn\n',
-      'hasn\n',
-      '\n',
-      'hellof\n',
-      '123\r'
-    ].join('');
+    var output = ["hasrn\n", "hasn\n", "\n", "hellof\n", "123\r"].join("");
 
     expect(escapeCarriageReturn(input)).to.equal(output);
-  })
+  });
+});
+
+describe("Escape carrigage return safe", function() {
+  it("safely escapes multiline text", function() {
+    var txt = escapeCarriageReturnSafe(
+      "This sentence\rThat\nwill make you\r pause even longer."
+    );
+    expect(txt).to.equal("That sentence\n pause even longer.");
+  });
+
+  it("safely escapes multiline text", function() {
+    var txt = escapeCarriageReturnSafe(
+      "This sentence\rThat\nwill make you\r pause."
+    );
+    expect(txt).to.equal("That sentence\nwill make you\r pause.");
+  });
+
+  it("can safely handle complicated carrigage symbol", function() {
+    var input = [
+      "hasrn\r\n",
+      "hasn\n",
+      "\n",
+      "abcdef\r",
+      "hello\n",
+      "ab3\r",
+      "x2\r\r",
+      "1\r"
+    ].join("");
+
+    var output = [
+      "hasrn\n",
+      "hasn\n",
+      "\n",
+      "hellof\n",
+      "ab3\r",
+      "x2\r",
+      "1\r"
+    ].join("");
+
+    expect(escapeCarriageReturnSafe(input)).to.equal(output);
+  });
+
+  it("safely escapes single line: 1\r2\r3", function() {
+    var txt = escapeCarriageReturnSafe("1\r2\r3");
+    expect(txt).to.equal("3");
+  });
+
+  it("safely escapes single line: 1\r23\r4", function() {
+    var txt = escapeCarriageReturnSafe("1\r23\r4");
+    expect(txt).to.equal("23\r4");
+  });
+
+  it("safely escapes complicated single line", function() {
+    var txt = escapeCarriageReturnSafe("12\rabcdef\rg\rhi\rjklm\rn");
+    expect(txt).to.equal("abcdef\rjklm\rn");
+  });
 });

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -1,4 +1,4 @@
-var escapeCarriageReturn = require("../index").escapeCarriageReturn;
+var escapeCarriageReturn = require("../index");
 var escapeCarriageReturnSafe = require("../index").escapeCarriageReturnSafe;
 var expect = require("chai").expect;
 


### PR DESCRIPTION
This allows us to use `escape-carriage` without knowing the full output: https://github.com/nteract/hydrogen/pull/772#discussion_r117064576