### PR TITLE
Improve performance a lot

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,9 @@ function escapeCarriageReturn(txt) {
   if (!/\r/.test(txt)) return txt;
   txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
   while (/\r/.test(txt)) {
-    txt = txt.replace(
-        /^([^\r\n]*)\r+([^\r\n]*)/mg,
-        (_, base, insert) => insert + base.slice(insert.length),
-    );
+    txt = txt.replace(/^([^\r\n]*)\r+([^\r\n]*)/gm, function (_, base, insert) {
+      return insert + base.slice(insert.length);
+    });
   }
   return txt;
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ function escapeCarriageReturn(txt) {
   if (!txt) return "";
   if (!/\r/.test(txt)) return txt;
   txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
-  while (/\r/.test(txt)) {
-    txt = txt.replace(/^([^\r\n]*)\r+([^\r\n]*)/gm, function (_, base, insert) {
+  while (/\r./.test(txt)) {
+    txt = txt.replace(/^([^\r\n]*)\r+([^\r\n]+)/gm, function (_, base, insert) {
       return insert + base.slice(insert.length);
     });
   }

--- a/index.js
+++ b/index.js
@@ -7,11 +7,11 @@ function escapeCarriageReturn(txt) {
   if (!txt) return "";
   if (!/\r/.test(txt)) return txt;
   txt = txt.replace(/\r+\n/gm, "\n"); // \r followed by \n --> newline
-  while (/\r[^$]/.test(txt)) {
-    var base = /^(.*)\r+/m.exec(txt)[1];
-    var insert = /\r+(.*)$/m.exec(txt)[1];
-    insert = insert + base.slice(insert.length, base.length);
-    txt = txt.replace(/\r+.*$/m, "\r").replace(/^.*\r/m, insert);
+  while (/\r/.test(txt)) {
+    txt = txt.replace(
+        /^([^\r\n]*)\r+([^\r\n]*)/mg,
+        (_, base, insert) => insert + base.slice(insert.length),
+    );
   }
   return txt;
 }

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -25,7 +25,7 @@ describe("Escape carrigage return", function() {
       "1\r"
     ].join("");
 
-    var output = ["hasrn\n", "hasn\n", "\n", "hellof\n", "123\r"].join("");
+    var output = ["hasrn\n", "hasn\n", "\n", "hellof\n", "123"].join("");
 
     expect(escapeCarriageReturn(input)).to.equal(output);
   });

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -25,7 +25,7 @@ describe("Escape carrigage return", function() {
       "1\r"
     ].join("");
 
-    var output = ["hasrn\n", "hasn\n", "\n", "hellof\n", "123"].join("");
+    var output = ["hasrn\n", "hasn\n", "\n", "hellof\n", "123\r"].join("");
 
     expect(escapeCarriageReturn(input)).to.equal(output);
   });


### PR DESCRIPTION
We have experienced performance problems with the carriage returns escaping in https://github.com/kubeshop/testkube/issues/3522. To solve the problem, I've improved the performance of this library.

#### Benchmarks

##### Before

```
$ node test/benchmark.js
With carriage: 4.586308136100013
Without carriage: 0.003953090100024565
```

##### After

```
$ node test/benchmark.js 
With carriage: 0.13167581839999964
Without carriage: 0.002920525800000701
```